### PR TITLE
Database migration helper functions

### DIFF
--- a/resources/md/database.md
+++ b/resources/md/database.md
@@ -43,14 +43,12 @@ The default configuration runs any new migrations on startup, but this can be ch
 Migrations can also be run via the REPL. The `migratus.core` namespace provides the following
 helper functions:
 
-* `(migratus.core/reset-db)` - resets the state of the database
-* `(migratus.core/migrate)` - runs the pending migrations
-* `(migratus.core/rollback)` - rolls back the last set of migrations
-* `(migratus.core/create-migration "add-guestbook-table")` - creates the up/down migration files with the given name
+* `(migratus.core/reset (:db.sql/migrations state/system))` - resets the state of the database
+* `(migratus.core/migrate (:db.sql/migrations state/system))` - runs the pending migrations
+* `(migratus.core/rollback (:db.sql/migrations state/system))` - rolls back the last set of migrations
+* `(migratus.core/create-migration (:db.sql/migrations state/system) "add-guestbook-table")` - creates the up/down migration files with the given name
 
-**important**: the database connection must be initialized before migrations can be run in the REPL
-
-Please refer to the [Database Migrations](/docs/migrations.html) section for more details.
+**Important**: the database connection must be initialized before migrations can be run in the REPL
 
 ### SQL Queries
 


### PR DESCRIPTION
The helper functions from `migratus.core` were specified without (:db.sql/migrations state/system) so they couldn't be copied and pasted directly to REPL to execute without problems. I assumed that since the last function: `(migratus.core/create-migration "add-guestbook-table")` provided the parameter, we would prefer these function calls to be complete.

If not, we can simply mention `(:db.sql/migrations state/system)` just under the list for clarity.

Also, `reset-db` seems to be just `reset` now, if I didn't miss anything.
Also removed a dead link at the very end.