### PR TITLE
DB-related corrections and clarifications

### DIFF
--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -416,8 +416,8 @@ denoted using `:` notation. Let's replace the existing queries with some of our 
 -- :name save-message! :! :n
 -- :doc creates a new message
 INSERT INTO guestbook
-(name, message)
-VALUES (:name, :message)
+(name, message, timestamp)
+VALUES (:name, :message, :timestamp)
 
 -- :name get-messages :? :*
 -- :doc selects all available messages
@@ -496,7 +496,7 @@ We'll create a new controller that will be responsible for saving new messages i
           (empty? message)
           (assoc-in [:flash :errors :message] "message is required"))
         (do
-          (query-fn :save-message! {:name name :message message})
+          (query-fn :save-message! {:name name :message message :timestamp (java.util.Date.)})
           (http-response/found "/")))
       (catch Exception e
         (log/error e "failed to save message!")

--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -361,7 +361,7 @@ CREATE TABLE guestbook
 (id INTEGER PRIMARY KEY AUTOINCREMENT,
  name VARCHAR(30),
  message VARCHAR(200),
- timestamp TIMESTAMP(7));
+ timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
 ```
 
 The guestbook table will store all the fields describing the message, such as the name of the
@@ -432,8 +432,7 @@ Now that our model is all set up, let's reload the application, and test our que
 (def query-fn (:db.sql/query-fn state/system))
 
 (query-fn :save-message! {:name      "m1"
-                          :message   "hello world"
-                          :timestamp (java.util.Date.)})
+                          :message   "hello world"})
 ;; => 1
 
 (query-fn :get-messages {})
@@ -496,7 +495,7 @@ We'll create a new controller that will be responsible for saving new messages i
           (empty? message)
           (assoc-in [:flash :errors :message] "message is required"))
         (do
-          (query-fn :save-message! {:name name :message message :timestamp (java.util.Date.)})
+          (query-fn :save-message! {:name name :message message})
           (http-response/found "/")))
       (catch Exception e
         (log/error e "failed to save message!")

--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -416,8 +416,8 @@ denoted using `:` notation. Let's replace the existing queries with some of our 
 -- :name save-message! :! :n
 -- :doc creates a new message
 INSERT INTO guestbook
-(name, message, timestamp)
-VALUES (:name, :message, :timestamp)
+(name, message)
+VALUES (:name, :message)
 
 -- :name get-messages :? :*
 -- :doc selects all available messages

--- a/resources/md/learning_clojure.md
+++ b/resources/md/learning_clojure.md
@@ -1,4 +1,4 @@
-This section provides links to online resources, books, and development environments for getting started Clojure.
+This section provides links to online resources, books, and development environments for getting started with Clojure.
 
 ### Online Clojure Guides
 
@@ -30,9 +30,10 @@ This section provides links to online resources, books, and development environm
 
 ### IDE Support
 
-There are a number of IDEs to choose from for Clojure development.
+There is a number of IDEs to choose from for Clojure development.
 
-* [Emacs](http://clojure-doc.org/articles/tutorials/emacs.html) - currently the most popular IDE choice for Clojure.
+* [Emacs](http://clojure-doc.org/articles/tutorials/emacs.html) - currently the most popular IDE for Clojure.
 * [IntelliJ](http://www.jetbrains.com/idea/download/) - IntelliJ provides an excellent Clojure development environment via the [Cursive plugin](http://cursiveclojure.com/).
-* [Visual Studio Code](https://code.visualstudio.com/) - Extensible editor featuring [Calva](https://github.com/BetterThanTomorrow/calva) plugin available from the editor Plugin Marketplace.
-* [Vim Iced](https://github.com/liquidz/vim-iced) - Full featured Clojure editing for Vim
+* [Visual Studio Code](https://code.visualstudio.com/) - Extensible editor featuring the [Calva](https://github.com/BetterThanTomorrow/calva) plugin available from the editor Plugin Marketplace.
+* [Vim Iced](https://github.com/liquidz/vim-iced) - Full-featured Clojure editing for Vim.
+* [Clojure Sublimed](https://github.com/tonsky/Clojure-Sublimed) - a Clojure support package for [Sublime Text](https://www.sublimetext.com/).


### PR DESCRIPTION
Changes in database.md are style corrections and a single clarification to reset from migratus.

Changes in guestbook.md are fixes to what I think might be a bug. In the migration we add the timestamp field, but in save-message! in queries.sql, we don't provide access to that field at all. As a result, the function call from lines 434-436 (save-message! from REPL) does not set the timestamp. On the other hand, the save-message! function we define to handle our form POST does not attempt to set the timestamp (which is technically correct, but doesn't use the timestamp field we defined in db migration).

For clarity, I'll also add comments per line.

I also added Sublime Text to the list of IDEs ;)