### PR TITLE
add the key for scheduling system.edn example

### DIFF
--- a/resources/md/scheduling.md
+++ b/resources/md/scheduling.md
@@ -17,6 +17,7 @@ There is a reference to a `:myapp.core/daily-job` which will should be defined a
 First in our `system.edn` we will define the component.
 
 ```clojure
+:myapp.core/daily-job
 {:identity          "myapp.core/daily-job"
  :description       "Runs once a day and prints hi"
  :recover?          true


### PR DESCRIPTION
For those of us that don't know integrant very well, it'd be nice for the scheduling example to include both the key and value to add to system.edn.