### PR TITLE
Fix server key in "System" section

### DIFF
--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -224,7 +224,7 @@ To confirm that your server is running, visit [http://localhost:3000/api/health]
 System resources such as HTTP server ports, database connections are defined in the `resources/system.edn` file. For example, this key defines HTTP server configuration such as the host, port, and HTTP handler:
 
 ```clojure
-:server/undertow
+:server/http
  {:port #long #or [#env PORT 3000]
   :host #or [#env HTTP_HOST "0.0.0.0"]
   :handler #ig/ref :handler/ring}


### PR DESCRIPTION
The [template](https://github.com/kit-clj/kit/blob/master/libs/lein-template/resources/leiningen/new/kit/resources/system.edn#L22) uses `:server/http`.

Should the [sample system config](https://github.com/kit-clj/kit/blob/master/libs/kit-generator/test/resources/sample-system.edn#L6) also be updated?