### PR TITLE
initial setup of devcontainer

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM clojure:temurin-20-tools-deps-jammy
+# Details as of 2023-09-19:
+# Ubuntu: Ubuntu 22.04 LTS (Jammy Jellyfish)
+# JDK: eclipse-temurin 20
+# Clojure: tools-deps, 1.11.1.1347
+
+# Extra tools
+RUN apt-get update && apt-get install -y gpg curl
+
+# Install new and clj-new (prefer new, but clj-new is needed for some templates)
+
+RUN clojure -Ttools install-latest :lib io.github.seancorfield/deps-new :as new
+RUN clojure -Ttools install-latest :lib com.github.seancorfield/clj-new :as clj-new
+
+# Add Babashka
+
+RUN curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install \
+  && chmod +x install \
+  && ./install --static

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Clojure kit tutorial",
+  "build": {
+    "dockerfile": "Dockerfile.dev"
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  // More info: https://containers.dev/features.
+  "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Run commands on cluster first start. Useful for download dependencies, etc.
+  // "postCreateCommand": "",
+  // Copy host env vars into the devcontainer.  You can also refer to some_file.env files in your docker or docker-compose setup.
+  "remoteEnv": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "betterthantomorrow.calva"
+      ]
+    }
+  }
+}

--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -7,6 +7,13 @@ project architecture.
 
 If you don't have a preferred Clojure editor already, then it's recommended that you use [Calva](https://calva.io/getting-started/) to follow along with this tutorial.
 
+## Quickstart via Devcontainers or Github Codespaces
+If you have configured your Github account, you can start the project without any other setup.  It will open a web-based vscode editor backed by a Github Codespace VM. (Codespaces is Github's hosted Devcontainer solution)
+
+[![Open in Github Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jwhitlark/kit-clj.github.io)
+
+You can also clone this repo locally, and using vscode (with the devcontainer plugin), and Docker Desktop, run an isolated, fully setup version of this application locally. Open the repo in your editor and run the command `Dev Containers: Open Folder in Container...`.
+
 ### Installing JDK
 
 Clojure runs on the JVM and requires a copy of JDK to be installed. If you don't


### PR DESCRIPTION
Gives a clean-room workspace with little to no setup for experimentation.

Note that the badge Open in Codespace will need to be edited to point at the parent repository. It can always be accessed through the Code button on the github site, by selecting Codespaces instead of Local on the pop-up menu.

