### PR TITLE
Update sessions.md: fix bug in clear-session!

### DIFF
--- a/resources/md/sessions.md
+++ b/resources/md/sessions.md
@@ -32,7 +32,7 @@ Below we have a simple example of interaction with the session.
 
 (defn clear-session! []
   (-> (response "Session cleared")
-      (dissoc :session)
+      (assoc :session nil)
       (assoc :headers {"Content-Type" "text/plain"})))
 
 (def app-routes


### PR DESCRIPTION
I believe there’s an error here… this implies that returning a response map without `:session` will clear the session, but as far as I can tell (this is my first time using this middleware) that’s not the case; rather one needs to return the response map with `:session nil` to clear the session.