### PR TITLE
Close `kit-sql-migratus` code block

### DIFF
--- a/resources/md/kit-sql-migratus.md
+++ b/resources/md/kit-sql-migratus.md
@@ -2,7 +2,7 @@
 
 ### :db.sql/migrations
 
-This component uses [migratus](https://github.com/yogthos/migratus) to execute your migrations. It optionally takes a `migrate-on-init?` key that defaults to `true`. When `true`, this key ensures your migrations run when the component is initialized. 
+This component uses [migratus](https://github.com/yogthos/migratus) to execute your migrations. It optionally takes a `migrate-on-init?` key that defaults to `true`. When `true`, this key ensures your migrations run when the component is initialized.
 
 The component resolves to the configuration options that are initially passed in.
 
@@ -19,3 +19,4 @@ Sample configuration:
   :migration-table-name "foo_bar"
   :db                   {:datasource #ig/ref :db.sql/connection}
   :migrate-on-init?     true}
+```


### PR DESCRIPTION
One of the libraries docs available in the Kit documentation - [`kit-sql-migratus`](https://kit-clj.github.io/docs/kit-sql-migratus.html) - has not the ending of the code block. Due to that rest of the page (**Topics**, **Libs** and footer) is formatted using monospace font. 

This PR comes with closing ticks to make sure rest of the page is rendered properly.