### PR TITLE
Replace deprecated `prep` with `expand` after integrant update

### DIFF
--- a/resources/md/integrant.md
+++ b/resources/md/integrant.md
@@ -35,7 +35,7 @@ In Kit, your Integrant components are defined in the `system.edn` file. This fil
 
 The full lifecycle of an Integrant component is:
 
-1) `prep`
+1) `expand`
 2) `init`
 3) `suspend` (stop but retain state)
 4) `resume`
@@ -84,7 +84,7 @@ If you would like to run your tests from the REPL, a helper function is generate
   []
   (integrant.repl/set-prep! (fn []
                               (-> (<project-ns>.config/system-config {:profile :test})
-                                  (ig/prep)))))
+                                  (ig/expand)))))
 ```
 
 This function uses the test profile regardless of your environment, allowing you to execute tests as if you were in that environment. This is particularly useful if you have a transient set of data sinks (databases, caches, etc.) for your test environment, and a permanent set for development.

--- a/resources/md/servers.md
+++ b/resources/md/servers.md
@@ -15,7 +15,7 @@ Undertow allows setting the number of worker and IO threads using the `:worker-t
 If you want to do a custom configuration that includes calculating the `io-threads` at runtime, you can override the default `ig/init-key` for `server/undertow`. This is the definition in `kit.edge.server.undertow`
 
 ```clojure
-(defmethod ig/prep-key :server/undertow
+(defmethod ig/expand-key :server/undertow
   [_ config]
   (merge {:port 3000
           :host "0.0.0.0"}
@@ -25,12 +25,12 @@ If you want to do a custom configuration that includes calculating the `io-threa
 For example,
 
 ```clojure
-(defmethod ig/prep-key :server/undertow
-  [_ config]
-  (merge {:port 3000
+(defmethod ig/expand-key :server/undertow
+  [k config]
+  {k (merge {:port 3000
           :host "0.0.0.0"
           :io-threads (* 2 (.availableProcessors (Runtime/getRuntime)))}
-         config))
+         config)})
 ```
 
 For a full listing of all configuration options, review the [ring-undertow-adapter documentation](https://github.com/luminus-framework/ring-undertow-adapter).

--- a/resources/md/servers.md
+++ b/resources/md/servers.md
@@ -16,10 +16,10 @@ If you want to do a custom configuration that includes calculating the `io-threa
 
 ```clojure
 (defmethod ig/expand-key :server/undertow
-  [_ config]
-  (merge {:port 3000
+  [k config]
+  {k (merge {:port 3000
           :host "0.0.0.0"}
-         config))
+         config)})
 ```
 
 For example,


### PR DESCRIPTION
This PR updates documentation about integrant component lifecycle and example server code related to preparing a component.

It is a follow-up change to [PR made to core repository](https://github.com/kit-clj/kit/pull/146).