### PR TITLE
Remove `persist-data? true` from defaults

### DIFF
--- a/resources/md/environment.md
+++ b/resources/md/environment.md
@@ -59,8 +59,7 @@ Kit uses `env/dev/clj` and `env/prod/clj` source paths for this purpose. By defa
    :stop       (fn []
                  (log/info "\n-=[ has shut down successfully]=-"))
    :middleware wrap-dev
-   :opts       {:profile       :dev
-                :persist-data? true}})
+   :opts       {:profile       :dev}})
 
 ```
 


### PR DESCRIPTION
This pull requests is simply a removal of outdated artifact from previous versions that adds `:persist-data? true` to the application defaults.

Addressing issue: https://github.com/kit-clj/kit/issues/157 

That change has been mapped in the code: https://github.com/kit-clj/kit/pull/159